### PR TITLE
Improve formatting of UML diagrams.

### DIFF
--- a/dataModel.tex
+++ b/dataModel.tex
@@ -10,13 +10,13 @@ As such, this section is also organized in pairs, first each interface class, th
 
 The \paml{Protocol} class represents an executable protocol.
 
-\begin{figure}[ht]
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/Protocol_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
+
 
 \subsection{Activity}
 \label{sec:Activity}
@@ -27,79 +27,84 @@ The \paml{Protocol} class represents an executable protocol.
 %%\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %%\label{uml:ProtocolInterface}
 %\end{center}
-%\end{figure}
+%
 
-\begin{figure}[ht]
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/Initial_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
 
-\begin{figure}[ht]
+
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/LocalValuePin_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
 
-\begin{figure}[ht]
+
+
 \begin{center}
-\includegraphics[scale=0.8]{uml/PrimitiveExecutable_abstraction_hierarchy.pdf}
+\includegraphics[width=\textwidth]{uml/PrimitiveExecutable_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
 
-\begin{figure}[ht]
+
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/Primitive_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
 
-\begin{figure}[ht]
+
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/PinSpecification_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
+
 
 \subsection{Flow}
 \label{sec:Flow}
 
 
-\begin{figure}[ht]
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/Flow_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
+
 
 \subsection{Location}
 \label{sec:Location}
 
-\begin{figure}[ht]
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/Location_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
+
 
 \subsection{LocatedSamples}
 \label{sec:LocatedSamples}
 
-\begin{figure}[ht]
+
 \begin{center}
 \includegraphics[scale=0.8]{uml/HeterogeneousSamples_abstraction_hierarchy.pdf}
 %\caption[]{Diagram of the \opil{ProtocolInterface} class and its associated properties}
 %\label{uml:ProtocolInterface}
 \end{center}
-\end{figure}
 
+
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: "paml"
+%%% End:


### PR DESCRIPTION
Removed the "figure" environments, because it creates floats, causing
the diagrams to move away from the relevant section headers.

Also rescaled one of the figures relative to `\textwidth` instead of
relative to the original figure size.  That kept it from running off
the margin.
