### PR TITLE
Ignore latex output files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+paml.aux
+paml.cb
+paml.cb2
+paml.log
+paml.out
+paml.pdf
+paml.synctex.gz
+paml.toc


### PR DESCRIPTION
Added a `.gitignore` file so no-one accidentally commits the many output files from latex.