### PR TITLE
fix formatting of build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ If the underlying PAML model has changed, and you need to rebuild the diagrams, 
 
 Run this in first the OPIL, then the PAML directory to build the UML:
 
+```
 cd OPIL
 pip3 install -e .
 cd ../PAML
 python3 -m opil -i paml/paml.ttl -n http://bioprotocols.org/paml# -d ../PAML-specification/uml -v
+```


### PR DESCRIPTION
This formats the commands using a fenced code block, so that GitHub doesn't render them all on one line.